### PR TITLE
Add continuous integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: cpp
+dist: xenial
+
+env:
+ - exten=intel64
+ - exten=knc
+ - exten=gccavx
+ - exten=neon
+
+script:
+ - make arch=$exten
+ - make arch=$exten run_selftest

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ env:
  - exten=neon
 
 script:
- - make arch=$exten
- - make arch=$exten run_selftest
+ - make arch=$(exten)
+ - make arch=$(exten) run_selftest

--- a/README.md
+++ b/README.md
@@ -1,29 +1,26 @@
-# OpenVec
+# OpenVec [![Travis Build Status](https://travis-ci.com/OpenVec/OpenVec.svg?branch=master)](https://travis-ci.com/OpenVec/OpenVec)
 OpenVec enables portable explicit vectorization on different architectures
 
-
-Just include "openvec.h" file in your C/C++ code and you are ready to go.
+Just include `openvec.h` file in your C/C++ code and you are ready to go.
 
 To compile code examples:
-make arch={intel64,knc,gccavx,neon}
+`make arch={intel64,knc,gccavx,neon}`
 
 If no arch is provided, gcc with SSE will be used.
 
 To run a self tests:
-make arch={intel64,knc,gccavx,neon} run_selftest
+`make arch={intel64,knc,gccavx,neon} run_selftest`
 
 The stencil* samples will allocate 3.9GB,
-if you want allocate less memory edit stencil_common.h
+if you want allocate less memory edit `stencil_common.h`
 and change problem size.
-Blocking definitions are located on stencil_common.h too.
+Blocking definitions are located on `stencil_common.h` too.
 
-
-
-Specific information for KNC:
+### Specific information for KNC:
 
 For compiling:
-make arch=knc
+`make arch=knc`
 
-And use knc_target=<device number> for running the tests on specific KNC device.
+And use `knc_target=<device number>` for running the tests on specific KNC device.
 For example, to run on device mic0:
-make arch=knc knc_target=0 run_selftest
+`make arch=knc knc_target=0 run_selftest`


### PR DESCRIPTION
Tests the Makefile with `make` and `make run_selftest` on Ubuntu 16.04.

For optimal integration with GitHub Travis CI needs to be [enabled](https://github.com/marketplace/travis-ci) on the GitHub Marketplace.